### PR TITLE
Redesign UI with Bootstrap and add user agent emulator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,20 +1,167 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <script src="https://cdn.jsdelivr.net/npm/ua-parser-js/dist/ua-parser.min.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>User Agent Explorer</title>
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv53mP3GsOJQy9VTMaJTdC0T0qyK+r6UksJ64m+xBq+AI8Q4dEjh"
+        crossorigin="anonymous"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/ua-parser-js@1.0.37/dist/ua-parser.min.js"></script>
+    <style>
+        body {
+            background-color: var(--bs-body-bg);
+        }
+
+        .ua-output {
+            background-color: var(--bs-tertiary-bg);
+            border: 1px solid var(--bs-border-color);
+            border-radius: var(--bs-border-radius);
+            padding: 1rem;
+            font-family: var(--bs-font-monospace);
+            white-space: pre-wrap;
+            word-break: break-word;
+            margin-bottom: 0;
+        }
+    </style>
 </head>
 <body>
-<p>Raw user agent string from browser:</p>
-<pre id="userAgentRaw">Not Found</pre>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark shadow-sm">
+        <div class="container">
+            <span class="navbar-brand mb-0 h1">User Agent Explorer</span>
+        </div>
+    </nav>
 
-<p>User Agent parsed by UAParser.js</p>
-<pre id="userAgentParsed"></pre>
+    <main class="py-5">
+        <div class="container">
+            <div class="row g-4">
+                <div class="col-lg-6">
+                    <div class="card shadow-sm h-100">
+                        <div class="card-header bg-primary text-white">
+                            <h2 class="h5 mb-0">Your Browser</h2>
+                        </div>
+                        <div class="card-body">
+                            <p class="text-body-secondary">
+                                Below is the user agent information reported by your current browser.
+                            </p>
+                            <h3 class="h6">Raw User Agent</h3>
+                            <pre id="userAgentRaw" class="ua-output">Loading…</pre>
+                            <h3 class="h6 mt-4">Parsed Details</h3>
+                            <pre id="userAgentParsed" class="ua-output">Loading…</pre>
+                        </div>
+                    </div>
+                </div>
 
-<script>
-    const uap = new UAParser();
-    console.log(uap.getResult());
-    document.getElementById('userAgentRaw').innerText = navigator.userAgent;
-    document.getElementById('userAgentParsed').innerText = JSON.stringify(uap.getResult(), null, 2);
-</script>
+                <div class="col-lg-6">
+                    <div class="card shadow-sm h-100">
+                        <div class="card-header bg-success text-white">
+                            <h2 class="h5 mb-0">Emulate Another Browser</h2>
+                        </div>
+                        <div class="card-body">
+                            <p class="text-body-secondary">
+                                Choose a preset to emulate a different browser's user agent string and see how it is parsed.
+                            </p>
+                            <label for="userAgentSelect" class="form-label">User agent presets</label>
+                            <select id="userAgentSelect" class="form-select" aria-label="User agent presets">
+                                <option value="">Select a preset…</option>
+                            </select>
+                            <div class="form-text">
+                                User agent strings are long — scroll horizontally to explore the details.
+                            </div>
+                            <h3 class="h6 mt-4">Emulated User Agent</h3>
+                            <pre id="emulatedUserAgent" class="ua-output">Select a preset to emulate.</pre>
+                            <h3 class="h6 mt-4">Parsed Details</h3>
+                            <pre id="emulatedUserAgentParsed" class="ua-output">Once selected, the parsed data will appear here.</pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
 
+    <footer class="py-4 bg-dark text-light">
+        <div class="container text-center">
+            <small>Powered by UAParser.js and Bootstrap.</small>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fc+hgpG1LgKmc90X4l1N6QcbFM9A7lGce0o9KcQ" crossorigin="anonymous"></script>
+    <script>
+        const userAgentPresets = [
+            {
+                label: "Google Chrome on Windows 11",
+                ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
+            },
+            {
+                label: "Microsoft Edge on Windows 11",
+                ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 Edg/113.0.1774.35",
+            },
+            {
+                label: "Mozilla Firefox on macOS",
+                ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 13.4; rv:113.0) Gecko/20100101 Firefox/113.0",
+            },
+            {
+                label: "Safari on iPhone iOS 16",
+                ua: "Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Mobile/15E148 Safari/604.1",
+            },
+            {
+                label: "Safari on iPad iPadOS 16",
+                ua: "Mozilla/5.0 (iPad; CPU OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Mobile/15E148 Safari/604.1",
+            },
+            {
+                label: "Chrome on Android 13",
+                ua: "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Mobile Safari/537.36",
+            },
+        ];
+
+        document.addEventListener("DOMContentLoaded", () => {
+            const userAgentRawElement = document.getElementById("userAgentRaw");
+            const userAgentParsedElement = document.getElementById("userAgentParsed");
+            const emulatedUserAgentElement = document.getElementById("emulatedUserAgent");
+            const emulatedParsedElement = document.getElementById("emulatedUserAgentParsed");
+            const selectElement = document.getElementById("userAgentSelect");
+
+            userAgentPresets.forEach((preset) => {
+                const option = document.createElement("option");
+                option.value = preset.ua;
+                option.textContent = preset.label;
+                selectElement.appendChild(option);
+            });
+
+            const actualParser = new UAParser();
+            userAgentRawElement.textContent = navigator.userAgent;
+            userAgentParsedElement.textContent = JSON.stringify(actualParser.getResult(), null, 2);
+
+            const resetEmulation = () => {
+                emulatedUserAgentElement.textContent = "Select a preset to emulate.";
+                emulatedParsedElement.textContent = "Once selected, the parsed data will appear here.";
+            };
+
+            const updateEmulation = (uaString) => {
+                if (!uaString) {
+                    resetEmulation();
+                    return;
+                }
+
+                const parser = new UAParser(uaString);
+                emulatedUserAgentElement.textContent = uaString;
+                emulatedParsedElement.textContent = JSON.stringify(parser.getResult(), null, 2);
+            };
+
+            selectElement.addEventListener("change", (event) => {
+                updateEmulation(event.target.value);
+            });
+
+            if (userAgentPresets.length > 0) {
+                selectElement.value = userAgentPresets[0].ua;
+                updateEmulation(userAgentPresets[0].ua);
+            } else {
+                resetEmulation();
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle the demo page with Bootstrap navigation, cards, and typography
- add a preset menu that loads example user agent strings for common browsers
- parse and display details for both the current browser and the selected preset

## Testing
- Manual validation in browser

------
https://chatgpt.com/codex/tasks/task_e_68ca02d1f724832e85d6bcc0bfe35163